### PR TITLE
Support more detailed log level configuration with the RUST_LOG env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
     * Low batter indicator
     * Transmitter power
     * All data in attributes for all sensors
+- Support more detailed log level configuration with the `RUST_LOG` env var ([#145](https://github.com/tmatilai/ruuvi2mqtt/pull/145)):
 
 # 1.1.1 / 2022-10-30
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,5 +81,8 @@ async fn main() -> Result<()> {
 }
 
 fn init_logger(log_level: log::LevelFilter) {
-    env_logger::Builder::new().filter_level(log_level).init();
+    env_logger::Builder::new()
+        .filter_level(log_level)
+        .parse_default_env()
+        .init();
 }

--- a/src/ruuvi/listener.rs
+++ b/src/ruuvi/listener.rs
@@ -65,8 +65,12 @@ impl RuuviListener {
         match event {
             CentralEvent::DeviceDiscovered(id) | CentralEvent::DeviceUpdated(id) => {
                 let peripheral = self.find_peripheral(&id).await?;
+                log::trace!("BLE Peripheral: {:?}", peripheral);
                 if let Some(values) = Self::parse_data(&peripheral).await? {
-                    let address = values.mac_address().context("BDAddr now found")?;
+                    log::trace!("Ruuvi event: {:?}", values);
+                    let address = values
+                        .mac_address()
+                        .context(format!("BDAddr not found: {}", peripheral))?;
                     let data = SensorData::new(address.into(), values);
                     // Sleep a bit to avoid multiple/simultaneus updates
                     sleep(self.sleep).await;

--- a/src/ruuvi/listener.rs
+++ b/src/ruuvi/listener.rs
@@ -70,7 +70,7 @@ impl RuuviListener {
                     log::trace!("Ruuvi event: {:?}", values);
                     let address = values
                         .mac_address()
-                        .context(format!("BDAddr not found: {}", peripheral))?;
+                        .context(format!("BDAddr not found: {:?}", peripheral))?;
                     let data = SensorData::new(address.into(), values);
                     // Sleep a bit to avoid multiple/simultaneus updates
                     sleep(self.sleep).await;


### PR DESCRIPTION
Make it possible to configure different log levels based on module. The `--log-level` option or `LOG_LEVEL` environment variable is still used as default level.

For example:
```bash
env RUST_LOG=ruuvi2mqtt=trace ./ruuvi2mqtt [...]
```

Also add more trace logging for BLE event parsing.