### PR TITLE
Add TLS support for MQTT connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## _Not released yet_
 
+- Add TLS support for MQTT connections (`tls`, `ca_file`, and `tls_insecure` config options).
 - Refactor device throttling methods.
 - Fix MQTT topic subscription not being restored after reconnecting to the broker.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetime"
@@ -1496,6 +1496,7 @@ dependencies = [
  "log",
  "rand",
  "rumqttc",
+ "rustls-native-certs",
  "ruuvi-sensor-protocol",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ futures = "0.3.32"
 log = "0.4.29"
 rand = "0.10.0"
 rumqttc = "0.25.1"
+rustls-native-certs = "0.8.3"
 ruuvi-sensor-protocol = "0.6.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.149"

--- a/ruuvi2mqtt.yaml
+++ b/ruuvi2mqtt.yaml
@@ -1,7 +1,19 @@
 mqtt:
   server: "homeassistant.local"
+  #port: 1883  # Default: 1883 (non-TLS) or 8883 (TLS)
+  # Enable TLS/SSL connection (default: false)
+  # When enabled without ca_file, uses OS certificate store
+  #tls: true
+  # Optional: Path to custom CA certificate bundle (PEM format)
+  # Use this for self-signed certificates or custom CAs
+  #ca_file: /path/to/ca-bundle.pem
+  # Skip TLS certificate verification (default: false)
+  # WARNING: Only use for testing — disables all certificate checks
+  #tls_insecure: false
   user: "ruuvi2mqtt"
   password: "changeme"
+  #client_id: "ruuvi2mqtt_<hostname>"
+  #base_topic: "ruuvi2mqtt"
   throttle: 60
 
 devices:

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,18 +22,29 @@ pub struct Config {
 #[derive(Debug, Deserialize)]
 pub struct Mqtt {
     pub server: String,
-    #[serde(default = "default_mqtt_port")]
-    pub port: u16,
+    #[serde(default)]
+    pub port: Option<u16>,
+    #[serde(default)]
+    pub tls: bool,
+    #[serde(default)]
+    pub tls_insecure: bool,
+    pub ca_file: Option<PathBuf>,
     pub user: Option<String>,
     #[debug("{}", fmt_secret(password.as_ref()))]
     pub password: Option<String>,
     #[serde(default = "default_mqtt_client_id")]
     pub client_id: String,
+    #[serde(default = "default_mqtt_base_topic")]
+    pub base_topic: String,
     #[serde_as(as = "DurationSeconds<u32, Flexible>")]
     #[serde(default = "default_mqtt_throttle")]
     pub throttle: Duration,
-    #[serde(default = "default_mqtt_base_topic")]
-    pub base_topic: String,
+}
+
+impl Mqtt {
+    pub fn port(&self) -> u16 {
+        self.port.unwrap_or(if self.tls { 8883 } else { 1883 })
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -72,10 +83,6 @@ pub fn version_info() -> String {
     CliOptions::command().render_long_version()
 }
 
-const fn default_mqtt_port() -> u16 {
-    1883
-}
-
 fn default_mqtt_throttle() -> Duration {
     let throttle = rand::rng().random_range(50..70);
     Duration::new(throttle, 0)
@@ -101,8 +108,64 @@ fn fmt_secret(value: Option<&String>) -> &str {
     }
 }
 
-#[test]
-fn verify_cli() {
-    use clap::CommandFactory;
-    CliOptions::command().debug_assert();
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verify_cli() {
+        use clap::CommandFactory;
+        CliOptions::command().debug_assert();
+    }
+
+    #[test]
+    fn mqtt_port_defaults_without_tls() {
+        let mqtt = Mqtt {
+            server: "localhost".into(),
+            port: None,
+            tls: false,
+            tls_insecure: false,
+            ca_file: None,
+            user: None,
+            password: None,
+            client_id: "test".into(),
+            base_topic: "test".into(),
+            throttle: Duration::from_secs(60),
+        };
+        assert_eq!(mqtt.port(), 1883);
+    }
+
+    #[test]
+    fn mqtt_port_defaults_with_tls() {
+        let mqtt = Mqtt {
+            server: "localhost".into(),
+            port: None,
+            tls: true,
+            tls_insecure: false,
+            ca_file: None,
+            user: None,
+            password: None,
+            client_id: "test".into(),
+            base_topic: "test".into(),
+            throttle: Duration::from_secs(60),
+        };
+        assert_eq!(mqtt.port(), 8883);
+    }
+
+    #[test]
+    fn mqtt_port_explicit_override() {
+        let mqtt = Mqtt {
+            server: "localhost".into(),
+            port: Some(9999),
+            tls: true,
+            tls_insecure: false,
+            ca_file: None,
+            user: None,
+            password: None,
+            client_id: "test".into(),
+            base_topic: "test".into(),
+            throttle: Duration::from_secs(60),
+        };
+        assert_eq!(mqtt.port(), 9999);
+    }
 }

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -1,9 +1,18 @@
 use std::time::Duration;
 
+use std::sync::Arc;
+
 use anyhow::{Context, Result};
+use rumqttc::tokio_rustls::rustls::client::danger::{
+    HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier,
+};
+use rumqttc::tokio_rustls::rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rumqttc::tokio_rustls::rustls::{
+    ClientConfig, DigitallySignedStruct, RootCertStore, SignatureScheme,
+};
 use rumqttc::{
     AsyncClient, ConnectReturnCode, Event as MqttEvent, EventLoop as MqttEventLoop, Incoming,
-    MqttOptions, QoS,
+    MqttOptions, QoS, TlsConfiguration, Transport,
 };
 use tokio::time::sleep;
 
@@ -40,7 +49,7 @@ impl Mqtt {
     }
 
     fn options(config: &config::Mqtt) -> Result<MqttOptions> {
-        let mut options = MqttOptions::new(&config.client_id, &config.server, config.port);
+        let mut options = MqttOptions::new(&config.client_id, &config.server, config.port());
         options.set_keep_alive(Duration::from_secs(15));
         if let Some(user) = &config.user {
             let password = config
@@ -50,7 +59,47 @@ impl Mqtt {
             options.set_credentials(user, password);
         }
 
-        // TODO: TLS
+        if !config.tls && config.ca_file.is_some() {
+            log::warn!("ca_file is set but TLS is disabled; the CA file will be ignored");
+        }
+
+        if config.tls {
+            let transport = if config.tls_insecure {
+                log::warn!("TLS certificate verification is disabled (tls_insecure: true)");
+                let tls_config = ClientConfig::builder()
+                    .dangerous()
+                    .with_custom_certificate_verifier(Arc::new(NoVerifier))
+                    .with_no_client_auth();
+                Transport::Tls(TlsConfiguration::Rustls(Arc::new(tls_config)))
+            } else if let Some(ca_file) = &config.ca_file {
+                let ca = std::fs::read(ca_file)
+                    .with_context(|| format!("Failed to read CA file: {}", ca_file.display()))?;
+                Transport::Tls(TlsConfiguration::Simple {
+                    ca,
+                    alpn: None,
+                    client_auth: None,
+                })
+            } else {
+                let native_certs = rustls_native_certs::load_native_certs();
+                if !native_certs.errors.is_empty() {
+                    return Err(anyhow::anyhow!(
+                        "Failed to load platform TLS certificates: {:?}",
+                        native_certs.errors
+                    ));
+                }
+                let mut root_cert_store = RootCertStore::empty();
+                for cert in native_certs.certs {
+                    root_cert_store
+                        .add(cert)
+                        .context("Failed to add platform TLS certificate")?;
+                }
+                let tls_config = ClientConfig::builder()
+                    .with_root_certificates(root_cert_store)
+                    .with_no_client_auth();
+                Transport::Tls(TlsConfiguration::Rustls(Arc::new(tls_config)))
+            };
+            options.set_transport(transport);
+        }
 
         Ok(options)
     }
@@ -83,6 +132,56 @@ impl Mqtt {
                 Err(err) => log::error!("Failed to publish: {err}"),
             }
         });
+    }
+}
+
+#[derive(Debug)]
+struct NoVerifier;
+
+impl ServerCertVerifier for NoVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, rumqttc::tokio_rustls::rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rumqttc::tokio_rustls::rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rumqttc::tokio_rustls::rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        vec![
+            SignatureScheme::RSA_PKCS1_SHA256,
+            SignatureScheme::RSA_PKCS1_SHA384,
+            SignatureScheme::RSA_PKCS1_SHA512,
+            SignatureScheme::ECDSA_NISTP256_SHA256,
+            SignatureScheme::ECDSA_NISTP384_SHA384,
+            SignatureScheme::ECDSA_NISTP521_SHA512,
+            SignatureScheme::RSA_PSS_SHA256,
+            SignatureScheme::RSA_PSS_SHA384,
+            SignatureScheme::RSA_PSS_SHA512,
+            SignatureScheme::ED25519,
+            SignatureScheme::ED448,
+        ]
     }
 }
 


### PR DESCRIPTION
Support TLS/SSL connections to the MQTT broker with three new config options: `tls`, `ca_file`, and `tls_insecure`. The default port automatically switches to 8883 when TLS is enabled.